### PR TITLE
Upgrade to libpg-query@16.0.1

### DIFF
--- a/database/animals.ts
+++ b/database/animals.ts
@@ -50,7 +50,7 @@ export const getAnimalsInsecure = cache(async () => {
     SELECT
       *
     FROM
-      animalss
+      animals
     ORDER BY
       id
   `;

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -50,7 +50,7 @@ export const getAnimalsInsecure = cache(async () => {
     SELECT
       *
     FROM
-      animals
+      animalss
     ORDER BY
       id
   `;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-config-upleveled": "^7.8.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "libpg-query": "^15.0.3-wasm.0.1",
+    "libpg-query": "^16.0.1",
     "prettier": "^3.2.5",
     "prettier-plugin-embed": "^0.4.13",
     "prettier-plugin-sql": "^0.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ devDependencies:
     version: 14.2.1(react-dom@18.2.0)(react@18.2.0)
   '@ts-safeql/eslint-plugin':
     specifier: ^2.0.3
-    version: 2.0.3(eslint@8.56.0)(libpg-query@15.0.3-wasm.0.1)(typescript@5.3.3)
+    version: 2.0.3(eslint@8.56.0)(libpg-query@16.0.1)(typescript@5.3.3)
   '@types/dotenv-safe':
     specifier: ^8.1.5
     version: 8.1.5
@@ -83,8 +83,8 @@ devDependencies:
     specifier: ^29.7.0
     version: 29.7.0
   libpg-query:
-    specifier: ^15.0.3-wasm.0.1
-    version: 15.0.3-wasm.0.1
+    specifier: ^16.0.1
+    version: 16.0.1
   prettier:
     specifier: ^3.2.5
     version: 3.2.5
@@ -483,12 +483,6 @@ packages:
       postcss-selector-parser: ^6.0.13
     dependencies:
       postcss-selector-parser: 6.0.15
-    dev: true
-
-  /@emnapi/runtime@0.43.1:
-    resolution: {integrity: sha512-Q5sMc4Z4gsD4tlmlyFu+MpNAwpR7Gv2errDhVJ+SOhNjWcx8UTqy+hswb8L31RfC8jBvDgcnT87l3xI2w08rAg==}
-    dependencies:
-      tslib: 2.6.2
     dev: true
 
   /@emnapi/runtime@0.45.0:
@@ -939,10 +933,6 @@ packages:
   /@eslint/js@8.56.0:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /@gar/promisify@1.1.3:
-    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
 
   /@humanwhocodes/config-array@0.11.14:
@@ -1556,20 +1546,24 @@ packages:
       fastq: 1.17.0
     dev: true
 
-  /@npmcli/fs@1.1.1:
-    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+  /@npmcli/agent@2.2.1:
+    resolution: {integrity: sha512-H4FrOVtNyWC8MUwL3UfjOsAihHvT1Pe8POj3JvjXhSTJipsZMtgUALCT4mGyYZNxymkUfOw3PUj6dE4QPp6osQ==}
+    engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
-      '@gar/promisify': 1.1.3
-      semver: 7.5.4
+      agent-base: 7.1.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
+      lru-cache: 10.2.0
+      socks-proxy-agent: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@npmcli/move-file@1.1.2:
-    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
-    engines: {node: '>=10'}
-    deprecated: This functionality has been moved to @npmcli/fs
+  /@npmcli/fs@3.1.0:
+    resolution: {integrity: sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      mkdirp: 1.0.4
-      rimraf: 3.0.2
+      semver: 7.5.4
     dev: true
 
   /@pkgjs/parseargs@0.11.0:
@@ -1675,17 +1669,12 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@tootallnate/once@1.1.2:
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
-    dev: true
-
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
     dev: true
 
-  /@ts-safeql/eslint-plugin@2.0.3(eslint@8.56.0)(libpg-query@15.0.3-wasm.0.1)(typescript@5.3.3):
+  /@ts-safeql/eslint-plugin@2.0.3(eslint@8.56.0)(libpg-query@16.0.1)(typescript@5.3.3):
     resolution: {integrity: sha512-sMvq8hjBY5leWhq5/j+bJ432aWJO1RGaQup3v9FtfCwgvkgWudSaJ7PoDe1SU4kO2bolkdj4ZQPexRc5MTZTrQ==}
     peerDependencies:
       libpg-query: '>=13.2.5'
@@ -1697,7 +1686,7 @@ packages:
       chokidar: 3.5.3
       esbuild: 0.17.17
       fp-ts: 2.16.2
-      libpg-query: 15.0.3-wasm.0.1
+      libpg-query: 16.0.1
       pg-connection-string: 2.5.0
       postgres: 3.4.3
       recast: 0.22.0
@@ -2160,6 +2149,11 @@ packages:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: true
 
+  /abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
+
   /acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
     dependencies:
@@ -2195,11 +2189,13 @@ packages:
       - supports-color
     dev: true
 
-  /agentkeepalive@4.5.0:
-    resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
-    engines: {node: '>= 8.0.0'}
+  /agent-base@7.1.0:
+    resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
+    engines: {node: '>= 14'}
     dependencies:
-      humanize-ms: 1.2.1
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /aggregate-error@3.1.0:
@@ -2282,14 +2278,6 @@ packages:
   /are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
-    dev: true
-
-  /are-we-there-yet@3.0.1:
-    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
@@ -2586,30 +2574,22 @@ packages:
       streamsearch: 1.1.0
     dev: false
 
-  /cacache@15.3.0:
-    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
-    engines: {node: '>= 10'}
+  /cacache@18.0.2:
+    resolution: {integrity: sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==}
+    engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
-      '@npmcli/fs': 1.1.1
-      '@npmcli/move-file': 1.1.2
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      glob: 7.2.3
-      infer-owner: 1.0.4
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
+      '@npmcli/fs': 3.1.0
+      fs-minipass: 3.0.3
+      glob: 10.3.10
+      lru-cache: 10.2.0
+      minipass: 7.0.4
+      minipass-collect: 2.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
-      mkdirp: 1.0.4
       p-map: 4.0.0
-      promise-inflight: 1.0.1
-      rimraf: 3.0.2
-      ssri: 8.0.1
+      ssri: 10.0.5
       tar: 6.2.0
-      unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
+      unique-filename: 3.0.0
     dev: true
 
   /call-bind@1.0.5:
@@ -3777,6 +3757,10 @@ packages:
       jest-util: 29.7.0
     dev: true
 
+  /exponential-backoff@3.1.1:
+    resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
+    dev: true
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -3914,6 +3898,13 @@ packages:
       minipass: 3.3.6
     dev: true
 
+  /fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      minipass: 7.0.4
+    dev: true
+
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -3960,20 +3951,6 @@ packages:
       console-control-strings: 1.1.0
       has-unicode: 2.0.1
       object-assign: 4.1.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    dev: true
-
-  /gauge@4.0.4:
-    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      aproba: 2.0.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
       signal-exit: 3.0.7
       string-width: 4.2.3
       strip-ansi: 6.0.1
@@ -4216,23 +4193,22 @@ packages:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
     dev: true
 
-  /http-proxy-agent@4.0.1:
-    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
-    engines: {node: '>= 6'}
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
@@ -4248,15 +4224,19 @@ packages:
       - supports-color
     dev: true
 
+  /https-proxy-agent@7.0.4:
+    resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-    dev: true
-
-  /humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
-    dependencies:
-      ms: 2.1.3
     dev: true
 
   /iconv-lite@0.6.3:
@@ -4301,10 +4281,6 @@ packages:
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-    dev: true
-
-  /infer-owner@1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
     dev: true
 
   /inflight@1.0.6:
@@ -4562,6 +4538,11 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
+
+  /isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
     dev: true
 
   /istanbul-lib-coverage@3.2.2:
@@ -5246,16 +5227,14 @@ packages:
       type-check: 0.4.0
     dev: true
 
-  /libpg-query@15.0.3-wasm.0.1:
-    resolution: {integrity: sha512-FWCvNK7IDdh8H9SZu9PyXRxvZ569ZP2E8npsXgw0qlIjiwHpJUvQrzZDlOD9QwE8vhny8BU4rQHv5FwLz24fdQ==}
+  /libpg-query@16.0.1:
+    resolution: {integrity: sha512-HGnForYkm1acNS3UXPjKyxp0I2X3UsGIsY28sLcERjPMWvz4H0umkPYycR8xRH65GOyLn7LoXux0ynASLShmRw==}
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 0.43.1
       '@mapbox/node-pre-gyp': 1.0.11
-      node-addon-api: 7.1.0
-      node-gyp: 8.4.1
+      node-addon-api: 1.7.2
+      node-gyp: 10.0.1
     transitivePeerDependencies:
-      - bluebird
       - encoding
       - supports-color
     dev: true
@@ -5331,28 +5310,22 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /make-fetch-happen@9.1.0:
-    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
-    engines: {node: '>= 10'}
+  /make-fetch-happen@13.0.0:
+    resolution: {integrity: sha512-7ThobcL8brtGo9CavByQrQi+23aIfgYU++wg4B87AIS8Rb2ZBt/MEaDqzA00Xwv/jUjAjYkLHjVolYuTLKda2A==}
+    engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
-      agentkeepalive: 4.5.0
-      cacache: 15.3.0
+      '@npmcli/agent': 2.2.1
+      cacache: 18.0.2
       http-cache-semantics: 4.1.1
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
       is-lambda: 1.0.1
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 1.4.1
+      minipass: 7.0.4
+      minipass-fetch: 3.0.4
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
       negotiator: 0.6.3
       promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1
-      ssri: 8.0.1
+      ssri: 10.0.5
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -5435,18 +5408,18 @@ packages:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
-  /minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
+  /minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      minipass: 3.3.6
+      minipass: 7.0.4
     dev: true
 
-  /minipass-fetch@1.4.1:
-    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
-    engines: {node: '>=8'}
+  /minipass-fetch@3.0.4:
+    resolution: {integrity: sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      minipass: 3.3.6
+      minipass: 7.0.4
       minipass-sized: 1.0.3
       minizlib: 2.1.2
     optionalDependencies:
@@ -5596,9 +5569,8 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /node-addon-api@7.1.0:
-    resolution: {integrity: sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==}
-    engines: {node: ^16 || ^18 || >= 20}
+  /node-addon-api@1.7.2:
+    resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
     dev: true
 
   /node-fetch@2.7.0:
@@ -5613,23 +5585,22 @@ packages:
       whatwg-url: 5.0.0
     dev: true
 
-  /node-gyp@8.4.1:
-    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
-    engines: {node: '>= 10.12.0'}
+  /node-gyp@10.0.1:
+    resolution: {integrity: sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==}
+    engines: {node: ^16.14.0 || >=18.0.0}
     hasBin: true
     dependencies:
       env-paths: 2.2.1
-      glob: 7.2.3
+      exponential-backoff: 3.1.1
+      glob: 10.3.10
       graceful-fs: 4.2.11
-      make-fetch-happen: 9.1.0
-      nopt: 5.0.0
-      npmlog: 6.0.2
-      rimraf: 3.0.2
+      make-fetch-happen: 13.0.0
+      nopt: 7.2.0
+      proc-log: 3.0.0
       semver: 7.5.4
       tar: 6.2.0
-      which: 2.0.2
+      which: 4.0.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
@@ -5653,6 +5624,14 @@ packages:
     hasBin: true
     dependencies:
       abbrev: 1.1.1
+    dev: true
+
+  /nopt@7.2.0:
+    resolution: {integrity: sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      abbrev: 2.0.0
     dev: true
 
   /normalize-package-data@2.5.0:
@@ -5681,16 +5660,6 @@ packages:
       are-we-there-yet: 2.0.0
       console-control-strings: 1.1.0
       gauge: 3.0.2
-      set-blocking: 2.0.0
-    dev: true
-
-  /npmlog@6.0.2:
-    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      are-we-there-yet: 3.0.1
-      console-control-strings: 1.1.0
-      gauge: 4.0.4
       set-blocking: 2.0.0
     dev: true
 
@@ -6075,13 +6044,9 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /promise-inflight@1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
+  /proc-log@3.0.0:
+    resolution: {integrity: sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: true
 
   /promise-retry@2.0.1:
@@ -6555,11 +6520,11 @@ packages:
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
     dev: true
 
-  /socks-proxy-agent@6.2.1:
-    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
-    engines: {node: '>= 10'}
+  /socks-proxy-agent@8.0.2:
+    resolution: {integrity: sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==}
+    engines: {node: '>= 14'}
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 7.1.0
       debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
@@ -6642,11 +6607,11 @@ packages:
       nearley: 2.20.1
     dev: true
 
-  /ssri@8.0.1:
-    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
-    engines: {node: '>= 8'}
+  /ssri@10.0.5:
+    resolution: {integrity: sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      minipass: 3.3.6
+      minipass: 7.0.4
     dev: true
 
   /stack-utils@2.0.6:
@@ -7189,14 +7154,16 @@ packages:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
-  /unique-filename@1.1.1:
-    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+  /unique-filename@3.0.0:
+    resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      unique-slug: 2.0.2
+      unique-slug: 4.0.0
     dev: true
 
-  /unique-slug@2.0.2:
-    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
+  /unique-slug@4.0.0:
+    resolution: {integrity: sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       imurmurhash: 0.1.4
     dev: true
@@ -7369,6 +7336,14 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      isexe: 3.1.1
     dev: true
 
   /wide-align@1.1.5:


### PR DESCRIPTION
⚠️ Probably don't merge, since `main` uses the Wasm version of `libpg-query`, which we are trying to get to run on Windows

Logs for [the workflow run](https://github.com/upleveled/next-js-example-winter-2024-atvie/actions/runs/7988065228/job/21811866124?pr=5) installing `libpg-query@16.0.1` on `Ubuntu 22.04.4 LTS`:

```
$ pnpm install
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +841
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 841, reused 0, downloaded 37, added 24
Progress: resolved 841, reused 0, downloaded 144, added 141
Progress: resolved 841, reused 0, downloaded 322, added 319
Progress: resolved 841, reused 0, downloaded 556, added 553
Progress: resolved 841, reused 0, downloaded 677, added 663
Progress: resolved 841, reused 0, downloaded 811, added 798
Progress: resolved 841, reused 0, downloaded 841, added 841, done
.../esbuild@0.17.17/node_modules/esbuild postinstall$ node install.js
.../esbuild@0.19.12/node_modules/esbuild postinstall$ node install.js
.../esbuild@0.17.17/node_modules/esbuild postinstall: Done
.../esbuild@0.19.12/node_modules/esbuild postinstall: Done
.../sharp@0.33.2/node_modules/sharp install$ node install/check
.../sharp@0.33.2/node_modules/sharp install: Done
.../node_modules/libpg-query install$ node-pre-gyp install --fallback-to-build
.../node_modules/libpg-query install: node-pre-gyp info it worked if it ends with ok
.../node_modules/libpg-query install: node-pre-gyp info using node-pre-gyp@1.0.11
.../node_modules/libpg-query install: node-pre-gyp info using node@20.11.1 | linux | x64
.../node_modules/libpg-query install: node-pre-gyp info check checked for "/home/runner/work/next-js-example-winter-2024-atvie/next-js-example-winter-2024-atvie/node_modules/.pnpm/libpg-query@16.0.1/node_modules/libpg-query/build/Release/queryparser.node" (not found)
.../node_modules/libpg-query install: node-pre-gyp http GET https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v16.0.1-node-v115-linux-x64.tar.gz
.../node_modules/libpg-query install: node-pre-gyp ERR! install response status 404 Not Found on https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v16.0.1-node-v115-linux-x64.tar.gz 
.../node_modules/libpg-query install: node-pre-gyp WARN Pre-built binaries not installable for libpg-query@16.0.1 and node@20.11.1 (node-v115 ABI, glibc) (falling back to source compile with node-gyp) 
.../node_modules/libpg-query install: node-pre-gyp WARN Hit error response status 404 Not Found on https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v16.0.1-node-v115-linux-x64.tar.gz 
.../node_modules/libpg-query install: gyp info it worked if it ends with ok
.../node_modules/libpg-query install: gyp info using node-gyp@9.4.1
.../node_modules/libpg-query install: gyp info using node@20.11.1 | linux | x64
.../node_modules/libpg-query install: gyp info ok 
.../node_modules/libpg-query install: gyp info it worked if it ends with ok
.../node_modules/libpg-query install: gyp info using node-gyp@9.4.1
.../node_modules/libpg-query install: gyp info using node@20.11.1 | linux | x64
.../node_modules/libpg-query install: gyp info find Python using Python version 3.10.12 found at "/usr/bin/python3"
.../node_modules/libpg-query install: gyp http GET https://nodejs.org/download/release/v20.11.1/node-v20.11.1-headers.tar.gz
.../node_modules/libpg-query install: gyp http 200 https://nodejs.org/download/release/v20.11.1/node-v20.11.1-headers.tar.gz
.../node_modules/libpg-query install: gyp http GET https://nodejs.org/download/release/v20.11.1/SHASUMS256.txt
.../node_modules/libpg-query install: gyp http 200 https://nodejs.org/download/release/v20.11.1/SHASUMS256.txt
.../node_modules/libpg-query install: gyp info spawn /usr/bin/python3
.../node_modules/libpg-query install: gyp info spawn args [
.../node_modules/libpg-query install: gyp info spawn args   '/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@8.15.3/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/libpg-query install: gyp info spawn args   'binding.gyp',
.../node_modules/libpg-query install: gyp info spawn args   '-f',
.../node_modules/libpg-query install: gyp info spawn args   'make',
.../node_modules/libpg-query install: gyp info spawn args   '-I',
.../node_modules/libpg-query install: gyp info spawn args   '/home/runner/work/next-js-example-winter-2024-atvie/next-js-example-winter-2024-atvie/node_modules/.pnpm/libpg-query@16.0.1/node_modules/libpg-query/build/config.gypi',
.../node_modules/libpg-query install: gyp info spawn args   '-I',
.../node_modules/libpg-query install: gyp info spawn args   '/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@8.15.3/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
.../node_modules/libpg-query install: gyp info spawn args   '-I',
.../node_modules/libpg-query install: gyp info spawn args   '/home/runner/.cache/node-gyp/20.11.1/include/node/common.gypi',
.../node_modules/libpg-query install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/libpg-query install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/libpg-query install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/20.11.1',
.../node_modules/libpg-query install: gyp info spawn args   '-Dnode_gyp_dir=/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@8.15.3/node_modules/pnpm/dist/node_modules/node-gyp',
.../node_modules/libpg-query install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/20.11.1/<(target_arch)/node.lib',
.../node_modules/libpg-query install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/next-js-example-winter-2024-atvie/next-js-example-winter-2024-atvie/node_modules/.pnpm/libpg-query@16.0.1/node_modules/libpg-query',
.../node_modules/libpg-query install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/libpg-query install: gyp info spawn args   '--depth=.',
.../node_modules/libpg-query install: gyp info spawn args   '--no-parallel',
.../node_modules/libpg-query install: gyp info spawn args   '--generator-output',
.../node_modules/libpg-query install: gyp info spawn args   'build',
.../node_modules/libpg-query install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/libpg-query install: gyp info spawn args ]
.../node_modules/libpg-query install: gyp info ok 
.../node_modules/libpg-query install: gyp info it worked if it ends with ok
.../node_modules/libpg-query install: gyp info using node-gyp@9.4.1
.../node_modules/libpg-query install: gyp info using node@20.11.1 | linux | x64
.../node_modules/libpg-query install: gyp info spawn make
.../node_modules/libpg-query install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/libpg-query install: make: Entering directory '/home/runner/work/next-js-example-winter-2024-atvie/next-js-example-winter-2024-atvie/node_modules/.pnpm/libpg-query@16.0.1/node_modules/libpg-query/build'
.../node_modules/libpg-query install:   CC(target) Release/obj.target/nothing/../../../node-addon-api@1.7.2/node_modules/node-addon-api/src/nothing.o
.../node_modules/libpg-query install: rm -f Release/obj.target/../../../node-addon-api@1.7.2/node_modules/node-addon-api/src/nothing.a Release/obj.target/../../../node-addon-api@1.7.2/node_modules/node-addon-api/src/nothing.a.ar-file-list; mkdir -p `dirname Release/obj.target/../../../node-addon-api@1.7.2/node_modules/node-addon-api/src/nothing.a`
.../node_modules/libpg-query install: ar crs Release/obj.target/../../../node-addon-api@1.7.2/node_modules/node-addon-api/src/nothing.a @Release/obj.target/../../../node-addon-api@1.7.2/node_modules/node-addon-api/src/nothing.a.ar-file-list
.../node_modules/libpg-query install:   COPY Release/nothing.a
.../node_modules/libpg-query install:   ACTION binding_gyp_queryparser_target_prebuild_dependencies libpg_query/include/pg_query.h
.../node_modules/libpg-query install: Cloning into 'libpg_query'...
.../node_modules/libpg-query install: Note: switching to '1ec38940e5c6f09a4c1d17a46d839a881c4f2db7'.
.../node_modules/libpg-query install: You are in 'detached HEAD' state. You can look around, make experimental
.../node_modules/libpg-query install: changes and commit them, and you can discard any commits you make in this
.../node_modules/libpg-query install: state without impacting any branches by switching back to a branch.
.../node_modules/libpg-query install: If you want to create a new branch to retain commits you create, you may
.../node_modules/libpg-query install: do so (now or later) by using -c with the switch command. Example:
.../node_modules/libpg-query install:   git switch -c <new-branch-name>
.../node_modules/libpg-query install: Or undo this operation with:
.../node_modules/libpg-query install:   git switch -
.../node_modules/libpg-query install: Turn off this advice by setting config variable advice.detachedHead to false
.../node_modules/libpg-query install: HEAD is now at 1ec3894 Release 16-5.1.0
.../node_modules/libpg-query install: make[1]: Entering directory '/tmp/tmp.Gel2bVDeOp/libpg_query'
.../node_modules/libpg-query install: compiling src/pg_query.c
.../node_modules/libpg-query install: compiling src/pg_query_deparse.c
.../node_modules/libpg-query install: compiling src/pg_query_fingerprint.c
.../node_modules/libpg-query install: compiling src/pg_query_json_plpgsql.c
.../node_modules/libpg-query install: compiling src/pg_query_normalize.c
.../node_modules/libpg-query install: compiling src/pg_query_outfuncs_json.c
.../node_modules/libpg-query install: compiling src/pg_query_outfuncs_protobuf.c
.../node_modules/libpg-query install: compiling src/pg_query_parse.c
.../node_modules/libpg-query install: compiling src/pg_query_parse_plpgsql.c
.../node_modules/libpg-query install: compiling src/pg_query_readfuncs_protobuf.c
.../node_modules/libpg-query install: Warning: protoc-gen-c not found, skipping protocol buffer regeneration
.../node_modules/libpg-query install: compiling src/pg_query_scan.c
.../node_modules/libpg-query install: compiling src/pg_query_split.c
.../node_modules/libpg-query install: compiling src/postgres_deparse.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_catalog_namespace.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_catalog_pg_proc.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_commands_define.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_nodes_bitmapset.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_nodes_copyfuncs.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_nodes_equalfuncs.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_nodes_extensible.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_nodes_list.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_nodes_makefuncs.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_nodes_nodeFuncs.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_nodes_nodes.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_nodes_value.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_parser_gram.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_parser_parser.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_parser_scan.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_parser_scansup.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_storage_ipc_ipc.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_tcop_postgres.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_activity_pgstat_database.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_adt_datum.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_adt_expandeddatum.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_adt_format_type.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_adt_numutils.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_adt_ruleutils.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_error_assert.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_error_elog.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_fmgr_fmgr.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_init_globals.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_mb_mbutils.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_misc_guc_tables.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_mmgr_alignedalloc.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_mmgr_aset.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_mmgr_generation.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_mmgr_mcxt.c
.../node_modules/libpg-query install: compiling src/postgres/src_backend_utils_mmgr_slab.c
.../node_modules/libpg-query install: compiling src/postgres/src_common_encnames.c
.../node_modules/libpg-query install: compiling src/postgres/src_common_hashfn.c
.../node_modules/libpg-query install: compiling src/postgres/src_common_keywords.c
.../node_modules/libpg-query install: compiling src/postgres/src_common_kwlookup.c
.../node_modules/libpg-query install: compiling src/postgres/src_common_psprintf.c
.../node_modules/libpg-query install: compiling src/postgres/src_common_stringinfo.c
.../node_modules/libpg-query install: compiling src/postgres/src_common_wchar.c
.../node_modules/libpg-query install: compiling src/postgres/src_pl_plpgsql_src_pl_comp.c
.../node_modules/libpg-query install: compiling src/postgres/src_pl_plpgsql_src_pl_funcs.c
.../node_modules/libpg-query install: compiling src/postgres/src_pl_plpgsql_src_pl_gram.c
.../node_modules/libpg-query install: compiling src/postgres/src_pl_plpgsql_src_pl_handler.c
.../node_modules/libpg-query install: compiling src/postgres/src_pl_plpgsql_src_pl_scanner.c
.../node_modules/libpg-query install: compiling src/postgres/src_port_pg_bitutils.c
.../node_modules/libpg-query install: compiling src/postgres/src_port_pgstrcasecmp.c
.../node_modules/libpg-query install: compiling src/postgres/src_port_qsort.c
.../node_modules/libpg-query install: compiling src/postgres/src_port_snprintf.c
.../node_modules/libpg-query install: compiling src/postgres/src_port_strerror.c
.../node_modules/libpg-query install: compiling src/postgres/src_port_strlcpy.c
.../node_modules/libpg-query install: compiling vendor/protobuf-c/protobuf-c.c
.../node_modules/libpg-query install: compiling vendor/xxhash/xxhash.c
.../node_modules/libpg-query install: Warning: protoc-gen-c not found, skipping protocol buffer regeneration
.../node_modules/libpg-query install: compiling protobuf/pg_query.pb-c.c
.../node_modules/libpg-query install: ar: creating libpg_query.a
.../node_modules/libpg-query install: make[1]: Leaving directory '/tmp/tmp.Gel2bVDeOp/libpg_query'
.../node_modules/libpg-query install:   CXX(target) Release/obj.target/queryparser/src/addon.o
.../node_modules/libpg-query install:   CXX(target) Release/obj.target/queryparser/src/helpers.o
.../node_modules/libpg-query install:   CXX(target) Release/obj.target/queryparser/src/sync.o
.../node_modules/libpg-query install:   CXX(target) Release/obj.target/queryparser/src/async.o
.../node_modules/libpg-query install:   SOLINK_MODULE(target) Release/obj.target/queryparser.node
.../node_modules/libpg-query install:   COPY Release/queryparser.node
.../node_modules/libpg-query install: make: Leaving directory '/home/runner/work/next-js-example-winter-2024-atvie/next-js-example-winter-2024-atvie/node_modules/.pnpm/libpg-query@16.0.1/node_modules/libpg-query/build'
.../node_modules/libpg-query install: gyp info ok 
.../node_modules/libpg-query install: node-pre-gyp info ok 
.../node_modules/libpg-query install: Done

dependencies:
+ @upleveled/ley 0.8.5
+ dayjs 1.11.10
+ dotenv-safe 9.0.0
+ next 14.1.0
+ postgres 3.4.3
+ react 18.2.0
+ react-dom 18.2.0
+ sass 1.70.0
+ secure-json-parse 2.7.0
+ server-only 0.0.1
+ sharp 0.33.2
+ tsx 4.7.0
+ zod 3.22.4

devDependencies:
+ @jest/globals 29.7.0
+ @playwright/test 1.41.2
+ @testing-library/jest-dom 6.4.2
+ @testing-library/react 14.2.1
+ @ts-safeql/eslint-plugin 2.0.3
+ @types/dotenv-safe 8.1.5
+ @types/node 20.11.16
+ @types/react 18.2.54
+ @types/react-dom 18.2.18
+ eslint-config-upleveled 7.8.0
+ jest 29.7.0
+ jest-environment-jsdom 29.7.0
+ libpg-query 16.0.1
+ prettier 3.2.5
+ prettier-plugin-embed 0.4.13
+ prettier-plugin-sql 0.18.0
+ stylelint 16.2.0
+ stylelint-config-upleveled 1.0.7
+ typescript 5.3.3
```

Linting the SQL queries is also working with [SafeQL](https://github.com/ts-safeql/safeql#readme) - which depends on `libpg-query`:

![Screenshot 2024-02-21 at 12 17 19](https://github.com/upleveled/next-js-example-winter-2024-atvie/assets/1935696/ceea0e20-0a9f-40fc-9f04-b08ba9e5b4cb)
